### PR TITLE
Add of CMakeLists.txt files to build mupdf_wrapper and pdf_reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.user
+src/mupdf_wrapper/build
+src/pdf_reader/build

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,6 @@ pacman -S make mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-qt-cre
 Run the following commands to build muPDF:
 ```
 cd lib/mupdf/
-make build=debug HAVE_X11=no HAVE_GLUT=no -j8 libs
-make HAVE_X11=no HAVE_GLUT=no -j8 libs
+XCFLAGS=-fPIC make build=debug HAVE_X11=no HAVE_GLUT=no -j8 libs
+XCFLAGS=-fPIC make HAVE_X11=no HAVE_GLUT=no -j8 libs
 ```

--- a/src/mupdf_wrapper/CMakeLists.txt
+++ b/src/mupdf_wrapper/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS YES CACHE BOOL "Export all symbols")
+
+set(var_target mupdf_wrapper)
+set(var_path_source src)
+project(Prj_${var_target})
+
+set(CMAKE_CXX_FLAGS "-pipe -fexceptions -pedantic -Wall -Wextra")
+
+add_definitions(-DMUPDF_WRAPPER)
+add_definitions(-DQT_DEPRECATED_WARNINGS)
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+include_directories(
+    include/mupdf_wrapper
+    ${CMAKE_CURRENT_LIST_DIR}/../../lib/mupdf/include
+)
+link_directories(
+    ${CMAKE_CURRENT_LIST_DIR}/../../lib/mupdf/build/release
+)
+
+file(GLOB_RECURSE var_sources ${var_path_source}/*.cpp)
+add_library(${var_target} SHARED ${var_sources})
+target_link_libraries(${var_target} Qt5::Core mupdf mupdfthird)
+
+install(TARGETS ${var_target} DESTINATION ${CMAKE_CURRENT_LIST_DIR}/build)

--- a/src/pdf_reader/CMakeLists.txt
+++ b/src/pdf_reader/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS YES CACHE BOOL "Export all symbols")
+
+set(var_target pdf_reader)
+set(var_path_source src)
+project(Prj_${var_target})
+
+set(CMAKE_CXX_FLAGS "-pipe -fexceptions -pedantic -Wall -Wextra")
+
+add_definitions(-DQT_DEPRECATED_WARNINGS)
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+QT5_ADD_RESOURCES(RES_SOURCES resources/resources.qrc)
+
+include_directories(
+    ${CMAKE_CURRENT_LIST_DIR}/../mupdf_wrapper/include
+    ${CMAKE_CURRENT_LIST_DIR}/../../lib/mupdf/include
+)
+link_directories(
+    ${CMAKE_CURRENT_LIST_DIR}/../mupdf_wrapper/build
+    ${CMAKE_CURRENT_LIST_DIR}/../../lib/mupdf/build/release
+)
+
+file(GLOB_RECURSE var_sources ${var_path_source}/*.cpp)
+add_executable(${var_target} ${var_sources} ${RES_SOURCES} ${UI_HEADERS})
+target_link_libraries(${var_target} Qt5::Core Qt5::Gui Qt5::Widgets mupdf mupdfthird mupdf_wrapper)
+
+install(TARGETS ${var_target} DESTINATION ${CMAKE_CURRENT_LIST_DIR}/build)


### PR DESCRIPTION
CMake configured to use dynamic linking. Apparently this requires to build mupdf lib with an additional -fPIC flags.


However, there is a strange runtime error in my machine, just after QT loading fonts:

```
[me@host]$ QT_DEBUG_PLUGINS=1 LD_LIBRARY_PATH=../../mupdf_wrapper/build/:../../../lib/mupdf/build/release/ strace -e trace=open -e verbose=all ../build/pdf_reader
[...]
open("/usr/lib/x86_64-linux-gnu/qt5/plugins/iconengines/libqsvgicon.so", O_RDONLY|O_CLOEXEC) = 6
Found metadata in lib /usr/lib/x86_64-linux-gnu/qt5/plugins/iconengines/libqsvgicon.so, metadata=
{
    "IID": "org.qt-project.Qt.QIconEngineFactoryInterface",
    "MetaData": {
        "Keys": [
            "svg",
            "svgz",
            "svg.gz"
        ]
    },
    "className": "QSvgIconPlugin",
    "debug": false,
    "version": 329473
}


Got keys from plugin meta data ("svg", "svgz", "svg.gz")
QFactoryLoader::QFactoryLoader() checking directory path "/home/t1t0/Desktop/pdf_reader_fork/src/pdf_reader/build/iconengines" ...
open("/usr/lib/x86_64-linux-gnu/qt5/plugins/iconengines/libqsvgicon.so", O_RDONLY|O_CLOEXEC) = 6
[...]
open("/home/t1t0/.cache/fontconfig//4be9850f182b35c1350b6bbf2e42601c-le64.cache-4", O_RDONLY|O_CLOEXEC) = 8
open("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", O_RDONLY) = 8
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0x10} ---
+++ killed by SIGSEGV +++
Segmentation fault
```
