### PR TITLE
Copy test files into the binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(src/pdf_reader)
 
 enable_testing()
 
-set(TEST_FILES ${CMAKE_SOURCE_DIR}/resources/test_files)
+set(TEST_FILES_DIRECTORY ${CMAKE_SOURCE_DIR}/resources/test_files)
+file(COPY ${TEST_FILES_DIRECTORY} DESTINATION ${BINARY_DIRECTORY})
 
-add_test(NAME mupdf_wrapper_test COMMAND mupdf_wrapper_test WORKING_DIRECTORY ${TEST_FILES})
+add_test(NAME mupdf_wrapper_test COMMAND mupdf_wrapper_test WORKING_DIRECTORY ${BINARY_DIRECTORY})

--- a/src/mupdf_wrapper/test/document_test.cpp
+++ b/src/mupdf_wrapper/test/document_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE("GIVEN one page empty document WHEN create new Document THEN Document 
     context->register_document_handlers();
 
     std::shared_ptr<mupdf_wrapper::Document> document;
-    REQUIRE_NOTHROW(document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf"));
+    REQUIRE_NOTHROW(document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf"));
 
     const auto mupdf_document = document->get();
     REQUIRE(nullptr != mupdf_document);
@@ -37,7 +37,7 @@ TEST_CASE("GIVEN one page empty document WHEN get total pages THEN total pages e
     const auto context = std::make_shared<mupdf_wrapper::Context>();
     context->register_document_handlers();
 
-    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf");
+    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf");
     REQUIRE(document->get_total_pages() == 1);
 }
 
@@ -46,6 +46,6 @@ TEST_CASE("GIVEN five pages empty document WHEN get total pages THEN total pages
     const auto context = std::make_shared<mupdf_wrapper::Context>();
     context->register_document_handlers();
 
-    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "five_pages_empty_document.pdf");
+    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/five_pages_empty_document.pdf");
     REQUIRE(document->get_total_pages() == 5);
 }

--- a/src/mupdf_wrapper/test/page_test.cpp
+++ b/src/mupdf_wrapper/test/page_test.cpp
@@ -11,7 +11,7 @@ TEST_CASE("GIVEN one page empty document WHEN create new Page from existing page
     const auto context = std::make_shared<mupdf_wrapper::Context>();
     context->register_document_handlers();
 
-    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf");
+    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf");
     CHECK(document->get_total_pages() == 1);
 
     std::shared_ptr<mupdf_wrapper::Page> page;
@@ -26,7 +26,7 @@ TEST_CASE("GIVEN one page empty document WHEN create new Page from negative page
     const auto context = std::make_shared<mupdf_wrapper::Context>();
     context->register_document_handlers();
 
-    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf");
+    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf");
 
     std::shared_ptr<mupdf_wrapper::Page> page;
     REQUIRE_THROWS_AS(page = std::make_shared<mupdf_wrapper::Page>(context, document, -1), std::runtime_error);
@@ -37,7 +37,7 @@ TEST_CASE("GIVEN one page empty document WHEN create new Page from unexisting pa
     const auto context = std::make_shared<mupdf_wrapper::Context>();
     context->register_document_handlers();
 
-    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf");
+    const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf");
     CHECK(document->get_total_pages() == 1);
 
     std::shared_ptr<mupdf_wrapper::Page> page;

--- a/src/mupdf_wrapper/test/pixmap_test.cpp
+++ b/src/mupdf_wrapper/test/pixmap_test.cpp
@@ -40,7 +40,7 @@ SCENARIO("Create Pixmap from page number", "[Pixmap]")
         const auto context = std::make_shared<mupdf_wrapper::Context>();
         context->register_document_handlers();
 
-        const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf");
+        const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf");
         CHECK(document->get_total_pages() == 1);
 
         const auto matrix = std::make_shared<mupdf_wrapper::Matrix>();
@@ -85,7 +85,7 @@ SCENARIO("Create empty Pixmap from empty page", "[Pixmap]")
         const auto context = std::make_shared<mupdf_wrapper::Context>();
         context->register_document_handlers();
 
-        const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_empty_document.pdf");
+        const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_empty_document.pdf");
         CHECK(document->get_total_pages() == 1);
 
         const auto matrix = std::make_shared<mupdf_wrapper::Matrix>();
@@ -111,7 +111,7 @@ SCENARIO("Create not empty Pixmap from not empty page", "[Pixmap]")
         const auto context = std::make_shared<mupdf_wrapper::Context>();
         context->register_document_handlers();
 
-        const auto document = std::make_shared<mupdf_wrapper::Document>(context, "one_page_not_empty_document.pdf");
+        const auto document = std::make_shared<mupdf_wrapper::Document>(context, "test_files/one_page_not_empty_document.pdf");
         CHECK(document->get_total_pages() == 1);
 
         const auto matrix = std::make_shared<mupdf_wrapper::Matrix>();


### PR DESCRIPTION
Copy test files into the binary directory to allow the execution of the tests within the IDE and make debugging easier.