### PR TITLE
Download Catch2 single include

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ jobs:
       - run:
           name: Update submodules
           command: >
-            mkdir -p ~/.ssh &&
-            touch ~/.ssh/known_hosts &&
-            ssh-keyscan github.com >> ~/.ssh/known_hosts &&
             git submodule update --init --recursive
       - run:
           name: Build muPDF library

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/catch2"]
-    path = lib/catch2
-    url = git@github.com:catchorg/Catch2.git
 [submodule "lib/mupdf"]
     path = lib/mupdf
     url = git://git.ghostscript.com/mupdf.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${BINARY_DIRECTORY})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BINARY_DIRECTORY})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BINARY_DIRECTORY})
 
+add_subdirectory(lib/Catch2)
 add_subdirectory(src/mupdf_wrapper)
 add_subdirectory(src/pdf_reader)
 

--- a/lib/Catch2/CMakeLists.txt
+++ b/lib/Catch2/CMakeLists.txt
@@ -1,0 +1,10 @@
+SET(single_include "${CMAKE_CURRENT_BINARY_DIR}/include/catch2/catch.hpp")
+
+if(NOT EXISTS "${single_include}")
+    message(STATUS "Downloading Catch2 from https://github.com/catchorg/Catch2")
+    file(DOWNLOAD "https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch2/catch.hpp" "${single_include}")
+endif()
+
+add_library(catch2 INTERFACE)
+
+target_include_directories(catch2 INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/src/mupdf_wrapper/CMakeLists.txt
+++ b/src/mupdf_wrapper/CMakeLists.txt
@@ -58,12 +58,8 @@ add_executable(mupdf_wrapper_test
     ${TEST_FILES}
 )
 
-target_include_directories(mupdf_wrapper_test
-    PRIVATE
-    ${CMAKE_SOURCE_DIR}/lib/catch2/single_include
-)
-
 target_link_libraries(mupdf_wrapper_test
     PRIVATE
     mupdf_wrapper
+    catch2
 )


### PR DESCRIPTION
- Download Catch2 single include instead of having the whole repository as a submodule.
- Remove not longer needed github.com from known_hosts in CI.